### PR TITLE
Fix desync with inventory.

### DIFF
--- a/src/main/java/com/arkflame/flamepearls/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/arkflame/flamepearls/listeners/PlayerInteractListener.java
@@ -47,6 +47,9 @@ public class PlayerInteractListener implements Listener {
                     event.setCancelled(true);
                     // Send a message to the player
                     player.sendMessage(messagesConfigHolder.getMessage("cooldown").replace("{time}", cooldownSeconds));
+                    // We have to update the inventory to fix the "double click" issue.
+                    // Because of the cooldown, the ender pearls in your inventory are taken away by 2 instead of 1.
+                    player.updateInventory();
                 } else {
                     // Set the current time as last pearl thrown
                     cooldownManager.updateLastPearl(player);


### PR DESCRIPTION
> Here's a fix for an issue where double-clicking would cause 2 ender feathers to disappear due to the cooldown. 

[Bug](https://youtu.be/TyIFjDBAVT4)