### PR TITLE
Checking not to send empty messages

### DIFF
--- a/src/main/java/com/arkflame/flamepearls/listeners/PlayerInteractListener.java
+++ b/src/main/java/com/arkflame/flamepearls/listeners/PlayerInteractListener.java
@@ -2,6 +2,7 @@ package com.arkflame.flamepearls.listeners;
 
 import java.text.DecimalFormat;
 
+import com.arkflame.flamepearls.utils.MessageUtil;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -46,7 +47,8 @@ public class PlayerInteractListener implements Listener {
                     // Cancel the interaction event
                     event.setCancelled(true);
                     // Send a message to the player
-                    player.sendMessage(messagesConfigHolder.getMessage("cooldown").replace("{time}", cooldownSeconds));
+                    MessageUtil.sendMessage(player, messagesConfigHolder.getMessage("cooldown")
+                            .replace("{time}", cooldownSeconds));
                 } else {
                     // Set the current time as last pearl thrown
                     cooldownManager.updateLastPearl(player);

--- a/src/main/java/com/arkflame/flamepearls/utils/MessageUtil.java
+++ b/src/main/java/com/arkflame/flamepearls/utils/MessageUtil.java
@@ -1,0 +1,13 @@
+package com.arkflame.flamepearls.utils;
+
+import org.bukkit.entity.Player;
+
+public class MessageUtil {
+    public static void sendMessage(Player player, String message) {
+        if(message.isEmpty()) {
+            return;
+        }
+
+        player.sendMessage(message);
+    }
+}


### PR DESCRIPTION
> I added this because I needed to hide the cooldown posts, I just use the cooldown setting as a double click defense so I don't accidentally throw 2 ender purls.