### PR TITLE
Remove unnecessary code.

### DIFF
--- a/src/main/java/com/arkflame/flamepearls/listeners/ProjectileHitListener.java
+++ b/src/main/java/com/arkflame/flamepearls/listeners/ProjectileHitListener.java
@@ -48,7 +48,7 @@ public class ProjectileHitListener implements Listener {
                     // Get the world of the location
                     World world = location.getWorld();
                     // Try to find the nearest safest position
-                    Location safeLocation = LocationUtil.findSafeLocation(location, origin != null ? origin : location, world);
+                    Location safeLocation = LocationUtil.findSafeLocation(location, origin, world);
                     // Will teleport
                     originManager.setAsWillTeleport(player);
                     // Teleport the player to that location


### PR DESCRIPTION
> We check that origin is not equal to null, in the block that is wrapped in `if(origin != null)`