### PR TITLE
Added damage during teleportation.

### DIFF
--- a/src/main/java/com/arkflame/flamepearls/listeners/EntityDamageByEntityListener.java
+++ b/src/main/java/com/arkflame/flamepearls/listeners/EntityDamageByEntityListener.java
@@ -1,5 +1,6 @@
 package com.arkflame.flamepearls.listeners;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.EnderPearl;
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
@@ -25,12 +26,11 @@ public class EntityDamageByEntityListener implements Listener {
             // Get the player and the ender pearl
             EnderPearl pearl = (EnderPearl) damager;
             // Check if the pearl was thrown by a different entity than the shooter
-            if (pearl.getShooter() != event.getEntity()) {
-                // Set the other damage
-                event.setDamage(generalConfigHolder.getPearlDamageOther());
-            } else {
-                // Set the self damage
-                event.setDamage(generalConfigHolder.getPearlDamageSelf());
+            double damage = pearl.getShooter() != event.getEntity()? generalConfigHolder.getPearlDamageOther()
+                    : generalConfigHolder.getPearlDamageSelf();
+
+            if(damage >= 0) {
+                event.setDamage(damage);
             }
         }
     }

--- a/src/main/java/com/arkflame/flamepearls/listeners/ProjectileHitListener.java
+++ b/src/main/java/com/arkflame/flamepearls/listeners/ProjectileHitListener.java
@@ -20,11 +20,13 @@ public class ProjectileHitListener implements Listener {
     private OriginManager originManager;
     private Sound sound;
     private double endermiteChance;
+    private GeneralConfigHolder generalConfigHolder;
 
     public ProjectileHitListener(OriginManager originManager, GeneralConfigHolder generalConfigHolder) {
         this.originManager = originManager;
         this.sound = generalConfigHolder.getPearlSound();
         this.endermiteChance = generalConfigHolder.getEndermiteChance();
+        this.generalConfigHolder = generalConfigHolder;
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -53,6 +55,11 @@ public class ProjectileHitListener implements Listener {
                     originManager.setAsWillTeleport(player);
                     // Teleport the player to that location
                     player.teleport(safeLocation.setDirection(player.getLocation().getDirection()), TeleportCause.ENDER_PEARL);
+                    // Dealing damage to the player as done in vanilla when teleporting.
+                    double damage = generalConfigHolder.getPearlDamageSelf();
+                    if(damage >= 0) {
+                        player.damage(damage);
+                    }
                     // Spawn endermite if chance is higher
                     if (endermiteChance > Math.random()) {
                         world.spawnEntity(safeLocation, org.bukkit.entity.EntityType.ENDERMITE);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,7 @@ disable-endermites: true
 endermite-chance: 0.1
 
 # Damage modifiers
+# Set the value to -1 for disable.
 pearl-damage-self: 5
 pearl-damage-other: 2
 


### PR DESCRIPTION
> During teleportation, if you just throw an ender pearl, the damage was not inflicted, which is kind of non-vanilla, and the function to enable this, I have not found.