### PR TITLE
Reset noDamageTicks after teleport.

### DIFF
--- a/src/main/java/com/arkflame/flamepearls/listeners/ProjectileHitListener.java
+++ b/src/main/java/com/arkflame/flamepearls/listeners/ProjectileHitListener.java
@@ -72,6 +72,8 @@ public class ProjectileHitListener implements Listener {
                     double damage = generalConfigHolder.getPearlDamageSelf();
                     if(damage >= 0) {
                         player.damage(damage, projectile);
+                        // Reset no damage tick due to player invulnerability in the server side.
+                        player.setNoDamageTicks(0);
                     }
                     // Spawn endermite if chance is higher
                     if (endermiteChance > Math.random()) {


### PR DESCRIPTION
When I get teleported the first time I take damage, then immediately to another location from another ender poral and I no longer take damage.

I set the vanilla noDamageTicks to zero because FlamePearls has his own teleport-no-damage-ticks.

https://github.com/user-attachments/assets/ca5e1e34-f1c1-4c28-a55a-66d0f4fd079c

