### PR TITLE
Api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.8.8-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ author: ${author}
 main: ${mainClass}
 version: ${version}
 url: ${url}
+api-version: 1.21
 commands:
   flamepearls:
     description: "FlamePearls improves general pearl behaviour and adds new mechanics."


### PR DESCRIPTION
New paper versions check to api-version in config and we need to set the version to avoid initializing legacy material support.
![image](https://github.com/user-attachments/assets/eb973ae7-ec15-4cf8-8dbf-64703bec0b9c)
