### PR TITLE
Reset fall damage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <!-- Build settings -->
     <build>
         <!-- Name of your compiled artifact -->
-        <finalName>${artifactId}</finalName>
+        <finalName>${project.artifactId}</finalName>
         <!-- Directory of .java files -->
         <sourceDirectory>src/main/java</sourceDirectory>
         <!-- Clean old builds and install dependencies before compile -->

--- a/src/main/java/com/arkflame/flamepearls/config/GeneralConfigHolder.java
+++ b/src/main/java/com/arkflame/flamepearls/config/GeneralConfigHolder.java
@@ -14,6 +14,10 @@ public class GeneralConfigHolder {
     private boolean disableEndermites = true;
     private double endermiteChance = 0.0;
 
+    // Reset fall damage after teleport
+    // It is necessary because if player fall and then teleported he receives damage from the falling too.
+    private boolean resetFallDamageAfterTeleport;
+
     // Damage modifiers
     private double pearlDamageSelf = 5;
     private double pearlDamageOther = 2;
@@ -31,6 +35,9 @@ public class GeneralConfigHolder {
         // Load disable endermites
         disableEndermites = config.getBoolean("disable-endermites", disableEndermites);
         endermiteChance = config.getDouble("endermite-chance", endermiteChance);
+
+        // Load reset fall damage value
+        resetFallDamageAfterTeleport = config.getBoolean("reset-fall-damage-after-teleport", resetFallDamageAfterTeleport);
 
         // Load no damage ticks after teleport.
         noDamageTicksAfterTeleport = config.getInt("teleport-no-damage-ticks");
@@ -65,6 +72,10 @@ public class GeneralConfigHolder {
 
     public boolean isDisableEndermites() {
         return disableEndermites;
+    }
+
+    public boolean isResetFallDamageAfterTeleport() {
+        return resetFallDamageAfterTeleport;
     }
 
     public double getPearlDamageSelf() {

--- a/src/main/java/com/arkflame/flamepearls/listeners/ProjectileHitListener.java
+++ b/src/main/java/com/arkflame/flamepearls/listeners/ProjectileHitListener.java
@@ -68,6 +68,9 @@ public class ProjectileHitListener implements Listener {
                     originManager.setAsWillTeleport(player);
                     teleportDataManager.add(player);
                     player.teleport(safeLocation.setDirection(player.getLocation().getDirection()), TeleportCause.ENDER_PEARL);
+                    if (generalConfigHolder.isResetFallDamageAfterTeleport()) {
+                        player.setFallDistance(0);
+                    }
                     // Dealing damage to the player as done in vanilla when teleporting.
                     double damage = generalConfigHolder.getPearlDamageSelf();
                     if(damage >= 0) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,9 @@ disable-endermites: true
 # Chance to spawn an endermite
 endermite-chance: 0.1
 
+# This option will force player to do not take fall damage after teleport from the plugin (ender pearls).
+reset-fall-damage-after-teleport: true
+
 # Damage modifiers
 pearl-damage-self: 5
 pearl-damage-other: 2


### PR DESCRIPTION
It is not necessary but i added it because of my damage. Players throw pearl and jumping from mountain, he think that he wont receive fall damage but damage is still persist, i added it as option because someone can want to keep this feature.